### PR TITLE
eliminate duplicate build-system initializer

### DIFF
--- a/cwl/python.scm
+++ b/cwl/python.scm
@@ -517,7 +517,6 @@ the older versions.")
         (base32
           "1rc8kf72v180qlygkh1y0jwv2fxqpx7n97bqfhbwgnn31iwai9g3"))))
   (build-system python-build-system)
-  (build-system python-build-system)
   (propagated-inputs
     `(
     ("python-more-itertools" ,python-more-itertools)


### PR DESCRIPTION
Including this channel in channels.scm and doing a `guix pull` resulted in this error:
```
|builder for `/gnu/store/xm1n0mcxbzz3rx197kbxn4j1x95c4nvy-guix-cwl.drv' failed to produce output path `/gnu/store/bbjl2i101wgmb99q50xqng9n0ss846p2-guix-cwl'                                                                                                                              
build of /gnu/store/xm1n0mcxbzz3rx197kbxn4j1x95c4nvy-guix-cwl.drv failed                                                                                                                                                                                                                  
View build log at '/var/log/guix/drvs/xm/1n0mcxbzz3rx197kbxn4j1x95c4nvy-guix-cwl.drv.bz2'.                                                                                                                                                                                                
cannot build derivation `/gnu/store/8nniwwylajanq87lpm5ahqlab5vsyfk9-profile.drv': 1 dependencies couldn't be built                                                                                                                                                                       
guix pull: error: build of `/gnu/store/8nniwwylajanq87lpm5ahqlab5vsyfk9-profile.drv' failed                                                                                                                                                                                               
$ bzcat /var/log/guix/drvs/xm/1n0mcxbzz3rx197kbxn4j1x95c4nvy-guix-cwl.drv.bz2                                                                                                                                                     
(repl-version 0 0)                                                                                                                                                                                                                                                                        
(exception syntax-error (value package) (value "duplicate field initializer") (value ((line . 519) (column . 2) (filename . "/gnu/store/y5ywrc8yqkhawf7wj63if3hhngjsfh4j-guix-cwl-1b2a26e/cwl/python.scm"))) (value (build-system python-build-system)) (value #f)) 
```

