### PR TITLE
Remove duplicate python-build-system (python-version)

### DIFF
--- a/cwl/python.scm
+++ b/cwl/python.scm
@@ -517,7 +517,6 @@ the older versions.")
         (base32
           "1rc8kf72v180qlygkh1y0jwv2fxqpx7n97bqfhbwgnn31iwai9g3"))))
   (build-system python-build-system)
-  (build-system python-build-system)
   (propagated-inputs
     `(
     ("python-more-itertools" ,python-more-itertools)


### PR DESCRIPTION
I've been following [1] on GNU Guix SD. I added the `guix-cwl` channel according to 'With GNU Guix channel' in `README.org`. After issuing `guix pull` I got the error:

```{guile}
(repl-version 0 0)
(exception syntax-error (value package) (value "duplicate field initializer") (value ((line . 519) (column . 2) (filename . "/gnu/store/y5ywrc8yqkhawf7wj63if3hhngjsfh4j-guix-cwl-1b2a26e/cwl/python.scm"))) (value (build-system python-build-system)) (value #f))
```

I guess this fixes the issue. I did not test it, as I'm new to Guix, and thus wanted to avoid messing with storing locally channel definitions and deviating from the README instructions.

[1]: https://hpc.guix.info/blog/2019/01/creating-a-reproducible-workflow-with-cwl/
