### PR TITLE
Append "python-cachecontrol" with "-0.11.7"

### DIFF
--- a/cwl/cwl.scm
+++ b/cwl/cwl.scm
@@ -62,7 +62,7 @@
      `(("git" ,git)
        ("node" ,node)
        ("python-bagit" ,python-bagit)
-       ("python-cachecontrol" ,python-cachecontrol) ; requires 0.12
+       ("python-cachecontrol-0.11.7" ,python-cachecontrol-0.11.7) ; requires 0.12
        ("python-arcp" ,python-arcp)
        ("python-setuptools-vtags" ,python-setuptools-vtags)
        ("python-dateutil" ,python-dateutil)
@@ -75,7 +75,7 @@
        ("python-mock" ,python-mock)
        ("python-subprocess32" ,python-subprocess32)
        ("python-ruamel.yaml" ,python-ruamel.yaml)
-       ("python-cachecontrol" ,python-cachecontrol)
+       ("python-cachecontrol-0.11.7" ,python-cachecontrol-0.11.7)
        ("python-lxml" ,python-lxml)
        ("python-mypy-extensions" ,python-mypy-extensions)
        ("python-mistune" ,python-mistune)
@@ -123,7 +123,7 @@
     (build-system python-build-system)
     (arguments `(#:tests? #f)) ;; CWL includes no tests.
     (inputs
-     `(("python-cachecontrol" ,python-cachecontrol) ; requires 0.12
+     `(("python-cachecontrol-0.11.7" ,python-cachecontrol-0.11.7) ; requires 0.12
        ("python-cython" ,python-cython)
        ("python-setuptools-vtags" ,python-setuptools-vtags)
        ("python-rdflib-jsonld" ,python-rdflib-jsonld)

--- a/cwl/python.scm
+++ b/cwl/python.scm
@@ -599,9 +599,9 @@ the older versions.")
     "Python bagit.")
    (license license:gpl2)))
 
-(define-public python-cachecontrol ; schema-salad requires a specific version
+(define-public python-cachecontrol-0.11.7 ; schema-salad requires a specific version
   (package
-    (name "python-cachecontrol")
+    (name "python-cachecontrol-0.11.7")
     (version "0.11.7")
     (source
      (origin
@@ -641,5 +641,5 @@ the older versions.")
 @code{httplib2} for use with @code{requests} session objects.")
     (license license:asl2.0)))
 
-(define-public python2-cachecontrol
-  (package-with-python2 python-cachecontrol))
+(define-public python2-cachecontrol-0.11.7
+  (package-with-python2 python-cachecontrol-0.11.7))


### PR DESCRIPTION
Removes conflict with the definition in gnu/packages/python-web.scm